### PR TITLE
Fixed indexing issue in sequence_charge_decoration

### DIFF
--- a/localcider/backend/sequence.py
+++ b/localcider/backend/sequence.py
@@ -399,7 +399,7 @@ class Sequence:
         """
         total=0
         for m in xrange(2,self.len+1):
-            for n in xrange(1,m-1):
+            for n in xrange(1,m):
                 total = total + float(self.chargePattern[m-1])*float(self.chargePattern[n-1])*np.power((m-n),0.5)
                 
         return total/self.len


### PR DESCRIPTION
The original indexing scheme was:
```
for m in xrange(2, self.len+1):
    for n in xrange(1, m-1):
        #calculate SCD contribution from n-th and m-th residues
```

This eliminates nearest-neighbor residues (i.e. the i-th and (i+1)-th residues) from the SCD calculation. The proposed change adjusts the for-loop over n to `xrange(1, m)`, thus including nearest-neighbor residues in the calculation, which appears to be what Sawle and Ghosh intended.

Thanks for all your efforts on localcider - it's incredibly useful!
-Andrew Lyon, Rosen Lab